### PR TITLE
Auto detect address type

### DIFF
--- a/script.js
+++ b/script.js
@@ -82,8 +82,10 @@ const updateCity = debounce(async (city) => {
     const data = await get(`https://nominatim.openstreetmap.org/search?q=${city}&format=json&addressdetails=1`);
 
     for (const location of data) {
-      if ('city' in location.address) {
-        geoLocation = { lat: location.lat, lon: location.lon, city: location.address.city, country: location.address.country, state: location.address.state };
+      const type = location.addresstype;
+
+      if (type) {
+        geoLocation = { lat: location.lat, lon: location.lon, city: location.address[type], country: location.address.country, state: location.address.state };
         cachedSunsetSunrise = null; // flush cached times
         render(true); // force immediate transition without fade
         return;


### PR DESCRIPTION
The returning object from the OSM api doesn't always have a "city" key in location.address, this change makes it choose the key according to location.addesstype which should always be present

location.addresstype will specify if the location is a city, town, village, municipality etc then it will look for that info inside location.address and save it as the geoLocation.city to be displayed as the current location in the wallpaper